### PR TITLE
Add support for boolean type in parser

### DIFF
--- a/parser/types.go
+++ b/parser/types.go
@@ -9,6 +9,8 @@ func mapType(source string) (name string) {
 		return "number"
 	case "string":
 		return "string"
+	case "bool":
+		return "boolean"
 	default:
 		return ""
 	}


### PR DESCRIPTION
The parser was previously unable to interpret boolean types. To extend its functionality, a new case for "bool" has been added in the switch statement which will return a "boolean". This will allow the parser to correctly identify and handle boolean types.